### PR TITLE
use devel space by default, make use of install space optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
             "default": "c++11",
             "description": "C++ standard to use  (see C_CPP extension)"
           },
+          "catkin_tools.useInstallSpace": {
+            "type": "boolean",
+            "default": "true",
+            "description": "Flag to source from install space instead of devel space"
+          },
           "catkin_tools.intelliSenseMode": {
             "type": "string",
             "default": "gcc-x64",

--- a/src/common/workspace.ts
+++ b/src/common/workspace.ts
@@ -570,10 +570,13 @@ export class Workspace {
 
   public async getSetupShell(): Promise<string> {
     const shell_type = getExtensionConfiguration('shell');
-    const install_dir = await this.workspace_provider.getInstallDir();
-    let setup = install_dir + `/setup.${shell_type}`;
-    if (fs.existsSync(setup)) {
-      return setup;
+    const use_install_space = getExtensionConfiguration('useInstallSpace');
+    if (use_install_space) {
+      const install_dir = await this.workspace_provider.getInstallDir();
+      let setup = install_dir + `/setup.${shell_type}`;
+      if (fs.existsSync(setup)) {
+        return setup;
+      }
     }
     const devel_dir = await this.workspace_provider.getDevelDir();
     return devel_dir + `/setup.${shell_type}`;


### PR DESCRIPTION
I'm having some issues fetching the test assets when running tests since it sources install space by default. Hence, I'm letting it source devel space by default and only source install space when set to do so. In my opinion sourcing from install space is rather rare when developing and also not the correct way for executing the tests, as it will assume that eventual test assets are also installed in install space, which is not done.

Fixes #36 