### PR TITLE
Remove dependency to 'vscode-test-explorer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For a colcon workspace, we expected a `colcon.meta` file to exist in the workspa
 ### CMAKE_EXPORT_COMPILE_COMMANDS
 
 Make sure that your catkin_tools workspace is set up to generate `compile_commands.json` files.
-This can be done by setting the `CMAKE_EXPORT_COMPILE_COMMANDS` flag to ON or 1 and re-building the workspace.  
+This can be done by setting the `CMAKE_EXPORT_COMPILE_COMMANDS` flag to ON or 1 and re-building the workspace.
 The `compile_commands.json` files are created for each package that is built inside the build folder.
 ```sh
 catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -95,7 +95,7 @@ This can be done by adding the following lines to the `c_cpp_properties.json` fi
 
 ### GTest targets
 
-This extensions registers itself as [TestExplorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer) adapter.
+This extensions registers itself as vscode [test API](https://code.visualstudio.com/api/extension-guides/testing) adapter.
 For this, all `CMakeLists.txt` are scanned for keywords hinting at the existence of `CTest` based unit tests, e.g. `catkin_add_gtest`.
 This is done with a list of regular expressions.
 If you have a custom macro for registering tests, you can customize this behavior via the `catkin_tools.gtestMacroRegex` property.
@@ -128,8 +128,8 @@ in your workspace settings.
 
 ## Tasks
 
-You can register catkin build as a build task in the following way.  
-- Press `ctrl+shift+p` > `Tasks: Configure Task` > `catkin_build: build` or `catkin_build: build current package` or `catkin_build: run current package tests`  
+You can register catkin build as a build task in the following way.
+- Press `ctrl+shift+p` > `Tasks: Configure Task` > `catkin_build: build` or `catkin_build: build current package` or `catkin_build: run current package tests`
 - If a `tasks.json` file does not exist, it will be created and a snippet similar to the following will be added. If `tasks.json` already exists, configuration settings are added only to the `"tasks"` section.
 
 ```json
@@ -149,9 +149,9 @@ You can register catkin build as a build task in the following way.
 	]
 }
 ```
-- Note: You can add multiple build tasks into a single `tasks.json` file by repeating the above steps.  
-- Note: Make sure that `"group": "build"` is present. If not add it. The task will then be available as a build task, i.e it will appear in the drop down menu when you press `ctrl+shift+b`.  
-- Note: To set a particular task as the default task, modify the `"group": "build"` to the following. If this is done, you can no longer choose the build tasks and only the default one will be executed when you press `ctrl+shift+b`.  
+- Note: You can add multiple build tasks into a single `tasks.json` file by repeating the above steps.
+- Note: Make sure that `"group": "build"` is present. If not add it. The task will then be available as a build task, i.e it will appear in the drop down menu when you press `ctrl+shift+b`.
+- Note: To set a particular task as the default task, modify the `"group": "build"` to the following. If this is done, you can no longer choose the build tasks and only the default one will be executed when you press `ctrl+shift+b`.
 ```json
 	"group": {
            	"kind": "build",
@@ -161,7 +161,7 @@ You can register catkin build as a build task in the following way.
 
 ## Building packages
 
-Press `ctrl+shift+b`. If a default build task is not set, you can can choose between the different build tasks available.  
-- `catkin_build: build` will build all the packages in the workspace.  
-- `catkin_build: build current package` will only build the package that the currently open file belongs to.  
-- `catkin_build: run current package tests` will only build the package that the currently open file belongs to and runs tests.  
+Press `ctrl+shift+b`. If a default build task is not set, you can can choose between the different build tasks available.
+- `catkin_build: build` will build all the packages in the workspace.
+- `catkin_build: build current package` will only build the package that the currently open file belongs to.
+- `catkin_build: run current package tests` will only build the package that the currently open file belongs to and runs tests.

--- a/package.json
+++ b/package.json
@@ -248,6 +248,5 @@
   "extensionDependencies": [
     "ms-vscode.cpptools",
     "compulim.compulim-vscode-closetag",
-    "hbenl.vscode-test-explorer"
   ]
 }


### PR DESCRIPTION
This pull request removes the dependency to the [vscode-test-explorer](https://github.com/hbenl/vscode-test-explorer#migrating-to-native-testing) since it will be deprecated now the vscode test API has been finalized (see [this announcement](https://github.com/hbenl/vscode-test-explorer#migrating-to-native-testing)). The tests seem to pass and the catkin tests show up in the new test explorer. I however do not know if the catkin-tools extension uses features that are found in the `vscode-test-explorer` which are not contained in the vscode test API.