### PR TITLE
Fix typo (missing bracket) in status text

### DIFF
--- a/src/common/cpp_tools_configuration_provider.ts
+++ b/src/common/cpp_tools_configuration_provider.ts
@@ -159,7 +159,7 @@ export class CppToolsConfigurationProvider implements CustomConfigurationProvide
             }
           });
           if (!found) {
-            setStatusText('(no usage of header file  found.');
+            setStatusText('(no usage of header file found.)');
           }
         } catch (error) {
           logger.error(error);


### PR DESCRIPTION
Simple typo fix.